### PR TITLE
Opções customizáveis para embeds do Spotify

### DIFF
--- a/src/features/battle/views/BattleView.vue
+++ b/src/features/battle/views/BattleView.vue
@@ -138,6 +138,13 @@
               @vote="voteForTrack"
               :can-vote="!currentBattle.winner"
               :winner-id="currentBattle.winner"
+              :embed-options="{
+                theme: 'dark',
+                autoplay: true,
+                utmSource: 'music-battle-fight-night',
+                utmMedium: 'battle-embed',
+                utmCampaign: 'track-battle-left'
+              }"
             />
           </v-col>
 
@@ -163,6 +170,13 @@
               @vote="voteForTrack"
               :can-vote="!currentBattle.winner"
               :winner-id="currentBattle.winner"
+              :embed-options="{
+                theme: 'dark',
+                autoplay: false,
+                utmSource: 'music-battle-fight-night',
+                utmMedium: 'battle-embed',
+                utmCampaign: 'track-battle-right'
+              }"
             />
           </v-col>
         </v-row>

--- a/src/features/spotify-integration/services/spotifyApiService.ts
+++ b/src/features/spotify-integration/services/spotifyApiService.ts
@@ -227,6 +227,7 @@ export class SpotifyApiService {
       await this.getCurrentUser()
       return true
     } catch (error) {
+      console.error('Token validation failed:', error)
       return false
     }
   }

--- a/src/features/spotify-integration/stores/spotifyStore.ts
+++ b/src/features/spotify-integration/stores/spotifyStore.ts
@@ -40,7 +40,7 @@ export const useSpotifyStore = defineStore('spotify', () => {
           const currentUser = await apiService.getCurrentUser()
           authState.value.user = currentUser
         } catch (error) {
-          console.warn('Stored token is invalid, clearing auth state')
+          console.warn('Stored token is invalid, clearing auth state', error)
           await logout()
         }
       }
@@ -139,6 +139,7 @@ export const useSpotifyStore = defineStore('spotify', () => {
           const playlists = await apiService.getAllUserPlaylists()
           userPlaylists.value = playlists
         } catch (refreshError) {
+          console.error('Error refreshing token:', refreshError)
           throw err // Throw original error
         }
       } else {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,4 @@
-import { beforeEach, vi } from 'vitest'
+import { beforeEach } from 'vitest'
 import { config } from '@vue/test-utils'
 
 // Mock Vuetify components


### PR DESCRIPTION
# 📦 O QUÊ
Opções customizáveis para embeds do Spotify no componente BattleMusicCard e melhora o tratamento de erros na integração com Spotify.

**Principais mudanças:**
- Adicionado interface `SpotifyEmbedOptions` para personalização de embeds
- Implementado sistema de parâmetros configuráveis para embeds do Spotify (tema, autoplay, modo compacto, UTM tracking)
- Melhorado logging de erros na validação e refresh de tokens
- Aplicado configurações diferenciadas para cards esquerdo e direito na batalha
- Removido import não utilizado no arquivo de setup de testes

# 🧐 O PORQUÊ
**Necessidade identificada:**
- Os embeds do Spotify estavam usando configurações fixas e limitadas
- Falta de controle sobre a experiência do usuário nos players embedded
- Logs de erro insuficientes para depuração de problemas de autenticação
- Necessidade de tracking personalizado para análise de engajamento

**Problema solucionado:**
- Permite personalização completa da experiência de embed do Spotify
- Facilita o debugging de problemas de autenticação
- Possibilita análise de dados mais granular através de UTM parameters

# 🎯 COMO
**Abordagem técnica:**
1. **Interface SpotifyEmbedOptions**: Criada interface TypeScript com propriedades opcionais para configuração de embeds
2. **URL Builder**: Implementado sistema dinâmico de construção de URLs com URLSearchParams
3. **Props com Defaults**: Configurado valores padrão sensatos para as opções de embed
4. **Altura Responsiva**: Ajustada altura do embed baseada no modo compacto
5. **Error Logging**: Adicionado logs detalhados para falhas de token
6. **Configuração Diferenciada**: Cards esquerdo e direito com configurações específicas (autoplay apenas no esquerdo)

**Funcionalidades implementadas:**
- Suporte a tema claro/escuro
- Modo compacto para economizar espaço
- Controle de autoplay por card
- Tracking UTM personalizado por posição
- Altura responsiva baseada no modo